### PR TITLE
correct links in docs/source/clusters/kaizen

### DIFF
--- a/docs/source/clusters/kaizen/Accessing-Northeastern-Cluster.md
+++ b/docs/source/clusters/kaizen/Accessing-Northeastern-Cluster.md
@@ -1,5 +1,5 @@
 # Accessing the Northeastern Cluster
-[Northeastern Cluster](clusters/kaizen/Northeastern-Cluster.html)
+[Northeastern Cluster](Northeastern-Cluster.html)
 
 ### Setting public access to HaaS node
 Two ways; manually or through HaaS via setting public network through HaaS master

--- a/docs/source/clusters/kaizen/Kaizen-Production.md
+++ b/docs/source/clusters/kaizen/Kaizen-Production.md
@@ -1,7 +1,7 @@
 # Kaizen Production
-[Trusted Users](clusters/kaizen/Trusted-Users.html)
+[Trusted Users](Trusted-Users.html)
 
-[Kaizen Backups Overview](clusters/kaizen/Kaizen-Backups-(SCC)-Overview.html)
+[Kaizen Backups Overview](Kaizen-Backups-(SCC)-Overview.html)
 
 ### Additional IP address range from CSAIL
   **VLAN 3802 128.31.24.0/22** - floating IPs and infrastructure with direct connection to Kumo/Engage1

--- a/docs/source/clusters/kaizen/Midonet.md
+++ b/docs/source/clusters/kaizen/Midonet.md
@@ -1,7 +1,7 @@
 # Midonet
 [RDO installation](https://www.rdoproject.org/networking/midonet-integration_mem-5-rhel-7-kilo-osp)
 
-[Midonet with MOC Kilo Openstack](clusters/kaizen/Midonet-with-openstack-Kilo-release-(MOC-puppet-deployment).html)
+[Midonet with MOC Kilo Openstack](Midonet-with-openstack-Kilo-release-(MOC-puppet-deployment).html)
 
 ### Devstack installation
 Ubuntu/redhat with 8 GB RAM and 4+ VCPUs.

--- a/docs/source/clusters/kaizen/Monitoring-in-NEU-Env.md
+++ b/docs/source/clusters/kaizen/Monitoring-in-NEU-Env.md
@@ -7,7 +7,7 @@ In order to log into those machines, you will first need send an email to Hua Li
 We've set up a sensu on a VM that is located on Haas Master. This VM have access to the IPMI network. 
 1. **Log on to Haas Master**
 
-    You can click [here](clusters/kaizen/Accessing-Northeastern-Cluster.html) for information about logging into Haas Master.
+    You can click [here](Accessing-Northeastern-Cluster.html) for information about logging into Haas Master.
 
 2. **Log on to the VM**
 ```

--- a/docs/source/clusters/kaizen/Northeastern-Cluster-Network-Documentation.md
+++ b/docs/source/clusters/kaizen/Northeastern-Cluster-Network-Documentation.md
@@ -1,6 +1,6 @@
 # Northeastern Cluster Network Documentation
 
-[Northeastern Cluster](clusters/kaizen/Northeastern-Cluster.html)
+[Northeastern Cluster](Northeastern-Cluster.html)
 
 * [VLANs and IP Addresses](#vlans-and-ip-addresses)
 * [Haas Master Config](#haas-master-config)

--- a/docs/source/clusters/kaizen/Northeastern-Cluster.md
+++ b/docs/source/clusters/kaizen/Northeastern-Cluster.md
@@ -1,14 +1,14 @@
 # Northeastern Cluster
-Instructions for [Accessing Northeastern Cluster](clusters/kaizen/Accessing-Northeastern-Cluster.html)
+Instructions for [Accessing Northeastern Cluster](Accessing-Northeastern-Cluster.html)
 
 ### Projects
-* [Kaizen Production](clusters/kaizen/Kaizen-Production.html)
-* [Monitoring in NEU Env.](clusters/kaizen/Monitoring-in-NEU-Env.html)
-* [Staging Area](clusters/kaizen/Staging-Area.html)
-* [VMs running on physical nodes](clusters/kaizen/VMs-running-on-nodes.html)
+* [Kaizen Production](Kaizen-Production.html)
+* [Monitoring in NEU Env.](Monitoring-in-NEU-Env.html)
+* [Staging Area](Staging-Area.html)
+* [VMs running on physical nodes](VMs-running-on-nodes.html)
 
 ### Equipment
-[NEU Equipment Sign-Out](clusters/kaizen/NEU-Equipment-Sign-Out.html)
+[NEU Equipment Sign-Out](NEU-Equipment-Sign-Out.html)
 
   **SERVERS**
   * Cisco UCS C220 M3 SSF (x48). See [this file](_static/pdf/CiscoConfiguration.pdf) for list of configuration components. 
@@ -25,24 +25,24 @@ Instructions for [Accessing Northeastern Cluster](clusters/kaizen/Accessing-Nort
 
   **SWITCHES**
   * Cisco Nexus 5672 (x2)
-  * More information at [Cisco Switches (NEU cluster)](clusters/kaizen/Cisco-Switches-(NEU-cluster).html)
+  * More information at [Cisco Switches (NEU cluster)](Cisco-Switches-(NEU-cluster).html)
   * Servers are connected to the switch ports in order 
     * on switch R3-C17, server 1 connects to port 1, server 2 to port 2, and so on up to server 24 to port 24.
     * on switch R3-C19, server 25 connects to port 1, server 48 to port 24.
 
   **STORAGE**
-[Fujitsu CD10000](clusters/kaizen/Fujitsu-CD10000.html)
+[Fujitsu CD10000](Fujitsu-CD10000.html)
 
   **Networks**
-[Northeastern Cluster Network Documentation](clusters/kaizen/Northeastern-Cluster-Network-Documentation.html)
+[Northeastern Cluster Network Documentation](Northeastern-Cluster-Network-Documentation.html)
 
 ### Setup/Configuration
-* [Kilo/RHEL-OSP-7 Deployment](clusters/kaizen/Kilo-RHEL-OSP-7-Deployment.html)
-* [Icehouse/Red Hat 7.0 Deployment Experimentation](clusters/kaizen/Icehouse-Red-Hat-7.0-Deployment-Experimentation.html)
+* [Kilo/RHEL-OSP-7 Deployment](Kilo-RHEL-OSP-7-Deployment.html)
+* [Icehouse/Red Hat 7.0 Deployment Experimentation](Icehouse-Red-Hat-7.0-Deployment-Experimentation.html)
 * [Installing CentOS 7 on a node hard drive](clusters/Installing-CentOS-7-on-a-node-hard-drive.html)
 
 ### Miscellaneous
-[Misc. errors/problems](clusters/kaizen/Misc.-errors-problems.html)
+[Misc. errors/problems](Misc.-errors-problems.html)
 
 ![](_static/img/NUManagementNetworkTopology.png)
 


### PR DESCRIPTION
documents in docs/source/clusters/kaizen were prefixing links to files
in the same directory with `clusters/kaizen`, resulting in invalid
links. This commit corrects those links.