### PR TITLE
add an attribution paragraph to spark on openshift

### DIFF
--- a/docs/source/archives-page/Spark-Cluster-On-Openshift.md
+++ b/docs/source/archives-page/Spark-Cluster-On-Openshift.md
@@ -1,3 +1,8 @@
+This work in heavily inspired by the
+[radanalytics.io SparkPi Tutorial](https://radanalytics.io/my-first-radanalytics-app.html),
+please see the [Python application instructions](https://radanalytics.io/assets/my-first-radanalytics-app/sparkpi-python-flask.html)
+for more information.
+
 Before starting this step, there are a few prerequisites which are necessary to ensure you have the proper tools and resources to complete the work.
 
 Access to an OpenShift cluster (which is https://openshift.massopen.cloud)

--- a/docs/source/openshift/Spark-on-OpenShift.md
+++ b/docs/source/openshift/Spark-on-OpenShift.md
@@ -1,3 +1,10 @@
+# Apache Spark on OpenShift
+
+This work in heavily inspired by the
+[radanalytics.io SparkPi Tutorial](https://radanalytics.io/my-first-radanalytics-app.html),
+please see the [Python application instructions](https://radanalytics.io/assets/my-first-radanalytics-app/sparkpi-python-flask.html)
+for more information.
+
 ## Installing Spark on Openshift
 Before starting this step, there are a few prerequisites which are necessary to ensure 
 you have the proper tools and resources to complete the work.


### PR DESCRIPTION
These articles contain text which was directly copied from the
radanalytics.io project tutorials. This change adds a paragraph at the
beginning of each article which properly attributes the upstream
sources.