### PR TITLE
Add IPs reserved by CSAIL

### DIFF
--- a/docs/source/clusters/kaizen2/Kaizen-2.md
+++ b/docs/source/clusters/kaizen2/Kaizen-2.md
@@ -156,14 +156,17 @@ IP Address       Hostname/Description
 ```
 IP Address       Hostname/Description
 128.52.60.1      default gateway
-128.52.60.2      Start: MOC Infrastrucure reserved
-128.52.60.10     End: MOC Infrastrucure reserved
 
-128.52.60.11     Smaug openshift cluster: API Virtual IP
-128.52.60.12     Smaug openshift cluster: Ingress Virtual IP
-128.52.60.13     CSAIL's `phoenix.csail.mit.edu`
-128.52.60.14     ocp-prod cluster: API Virtual IP
-128.52.60.15     ocp-prod cluster: Ingress Virtual IP
+128.52.60.2      Start: CSAIL Reserved
+128.52.60.20     End: CSAIL Reserved
+
+128.52.60.21     Start: MOC Infrastructure reserved
+128.52.60.30     End: MOC Infrastructure reserved
+
+128.52.60.31     Smaug openshift cluster: API Virtual IP
+128.52.60.32     Smaug openshift cluster: Ingress Virtual IP
+128.52.60.33     ocp-prod cluster: API Virtual IP
+128.52.60.34     ocp-prod cluster: Ingress Virtual IP
 
 128.52.61.0      Start: Smaug openshift cluster Tenant IP (128.52.61.0/25)
 128.52.61.127    End: Smaug openshift cluster Tenant IP (128.52.61.0/25)


### PR DESCRIPTION
Reallocate the VLANs since CSAIL may use the first 20 IPs for themselves.