### PR TITLE
Reserve VLAN and IPs for ocp-staging cluster

### DIFF
--- a/docs/source/clusters/MOC-VLAN-Distribution.md
+++ b/docs/source/clusters/MOC-VLAN-Distribution.md
@@ -78,7 +78,8 @@ Below is the detailed distribution of the VLANs.
 | 209  | Openshift Internal (Baremetal 4.x)                      | --             |
 | 210  | NFS for zero cluster                                    | 10.253.0.0/23  |
 | 211  | New England Storage Exchange (NESE)                     | 10.120.0.0/22  |
-| 249  | Ceph Cluster (internal)                                 |192.168.40.0/23 |  
+| 212  | Openshift Staging Internal (`ocp-staging`)              | --             |
+| 249  | Ceph Cluster (internal)                                 |192.168.40.0/23 |
 | 250  | Ceph public (for clients)                               | 192.168.0.0/19 |
 | 259  | Staging - Foreman                                       | 172.17.0.0/19  |
 | 270  | Staging - Internal API                                  | To be decided  |

--- a/docs/source/clusters/kaizen2/Kaizen-2.md
+++ b/docs/source/clusters/kaizen2/Kaizen-2.md
@@ -167,6 +167,8 @@ IP Address       Hostname/Description
 128.52.60.32     Smaug openshift cluster: Ingress Virtual IP
 128.52.60.33     ocp-prod cluster: API Virtual IP
 128.52.60.34     ocp-prod cluster: Ingress Virtual IP
+128.52.60.35     ocp-staging cluster: API Virtual IP
+128.52.60.36     ocp-staging cluster: Ingress Virtual IP
 
 128.52.61.0      Start: Smaug openshift cluster Tenant IP (128.52.61.0/25)
 128.52.61.127    End: Smaug openshift cluster Tenant IP (128.52.61.0/25)


### PR DESCRIPTION
We'll need to have some IPs and a VLAN reserved for the staging cluster.