### PR TITLE
Reclaim bunch of public IPs and other VLANs

### DIFF
--- a/docs/source/networking/kaizen-networks.md
+++ b/docs/source/networking/kaizen-networks.md
@@ -3,9 +3,7 @@ This documents lists out all hosts on all Kaizen VLANs.
 
 ## Public Neu (VLAN 127)
 
--  192.12.185.247      kzn-e.massopen.cloud emergency connection is through BU public net
 -  Subnet: 129.10.5.0/24
-
 ```
 IP Address       Hostname/Description
 129.10.5.1       Router IP (on cisco switch) (Highly Available)
@@ -13,21 +11,12 @@ IP Address       Hostname/Description
 129.10.5.3       Router IP (on cisco switch)
 129.10.5.4       kzn-hil-client.infra.massopen.cloud
 
-129.10.5.32      node-32 (old kaizen controller-1)
-
-129.10.5.39      node-39 (old kaizen services box)
 129.10.5.40      dns server for openshift subdomains (openapp.cloud, mocapps.cloud, massopen.cloud test subdomains)
 129.10.5.41      dns server for massopen.cloud
-
-129.10.5.47      node-47 (old kaizen controller-2)
-129.10.5.48      kzn-h.infra.massopen.cloud (node-48)
-
-129.10.5.50      Virtual IP for openstack horizon (kaizen.massopen.cloud)
 
 129.10.5.55      dhcp1.cnv.massopen.cloud
 129.10.5.56      dhcp2.cnv.massopen.cloud
 
-129.10.5.100     kaizen.massopen.cloud
 129.10.5.101     ov1.massopen.cloud
 129.10.5.102     ov2.massopen.cloud
 129.10.5.103     ov3.massopen.cloud 192.12.185.247 *129.10.5.103* is local only
@@ -38,35 +27,30 @@ IP Address       Hostname/Description
 129.10.5.108     mochat.infra.massopen.cloud (shared repo server)
 129.10.5.109     kzn-nagios.infra.massopen.cloud
 129.10.5.110     rhel-6-repomirror.massopen.cloud
-129.10.5.111     control1.massopen.cloud
-129.10.5.112     control2.massopen.cloud
-129.10.5.113     control3.massopen.cloud
-129.10.5.114     wl.massopen.cloud
+
+129.10.5.114     wl.massopen.cloud (to be deleted)
 129.10.5.115     tld.massopen.cloud
 129.10.5.116     freeipa.infra.massopen.cloud
-129.10.5.117     osticket.massopen.cloud
-129.10.5.118     sso2.massopen.cloud
+
 129.10.5.119     dns.massopen.cloud
-129.10.5.120     helpdeskvm.massopen.cloud
+129.10.5.120     helpdeskvm.massopen.cloud (to be deleted)
 129.10.5.121     massopen.cloud
-129.10.5.122     DVBackup
-129.10.5.123     reports.infra.massopen.cloud
+129.10.5.123     reports.infra.massopen.cloud (to be deleted)
 129.10.5.124     kzn-ipmi2-gw.infra.massopen.cloud
-129.10.5.125     kaizen.massopen.cloud - info page and redirect to kaizenold
-129.10.5.126     kumo-e.massopen.cloud
-129.10.5.127     kzn-hil.massopen.cloud
+
+129.10.5.127     kzn-hil.massopen.cloud (to be deleted)
 129.10.5.128     kzn-ovpn.massopen.cloud
-129.10.5.129     e1-emergency.massopen.cloud
 
 129.10.5.132     zabbix.massopen.cloud
 
-129.10.5.133     rz.massopen.cloud (Research Zabbix)
-129.10.5.134     mondata.massopen.cloud
+129.10.5.133     rz.massopen.cloud (Research Zabbix, to be deleted)
+129.10.5.134     mondata.massopen.cloud (to be deleted)
 
 129.10.5.136     elk.massopen.cloud (powered off, so ping won't respond)
-129.10.5.137     promtest.infra.massopen.cloud
-129.10.5.138     p9con.massopen.cloud
+129.10.5.137     promtest.infra.massopen.cloud (to be deleted)
+
 129.10.5.139     kumo-hil-client.infra.massopen.cloud (because BU network is down).
+
 129.10.5.140     esi-undercloud.massopen.cloud
 129.10.5.141     esi-controller-0.massopen.cloud
 129.10.5.142     esi-controller-1.massopen.cloud
@@ -85,70 +69,7 @@ IP Address       Hostname/Description
 ```
 IP Address       Hostname/Description
 192.12.185.1     default gateway
-192.12.185.21    api.ocp4-aio.cnv2.massopen.cloud
-192.12.185.22    *.apps.ocp4-aio.cnv2.massopen.cloud
-192.12.185.32    start cnv loadbalancer range (192.12.185.32/27)
-192.12.185.63    end cnv loadbalancer range
-192.12.185.64    general dynamic range start
-192.12.185.100   general dynamic range stop
-192.12.185.101   dhcp1-bm.cnv.massopen.cloud
-192.12.185.102   dhcp2-bm.cnv.massopen.cloud
-192.12.185.103   provisioner.cnv.massopen.cloud
-192.12.185.104   api.cnv.massopen.cloud
-192.12.185.105   ingres-lb.cnv.massopen.cloud
-192.12.185.106   ns1.cnv.massopen.cloud
-192.12.185.107   bootstrap.cnv.massopen.cloud
-192.12.185.110   os-mgr-0.cnv.massopen.cloud
-192.12.185.111   os-mgr-1.cnv.massopen.cloud
-192.12.185.112   os-mgr-2.cnv.massopen.cloud
-192.12.185.115   os-wrk-0.cnv.massopen.cloud
-192.12.185.116   os-wrk-1.cnv.massopen.cloud
-192.12.185.117   os-wrk-2.cnv.massopen.cloud
-192.12.185.120   m01.osh.massopen.cloud
-192.12.185.121   m02.osh.massopen.cloud
-192.12.185.122   m03.osh.massopen.cloud
-192.12.185.123   m04.osh.massopen.cloud
-192.12.185.124   m05.osh.massopen.cloud
-192.12.185.125   m06.osh.massopen.cloud
-192.12.185.130   os-sto-0.cnv.massopen.cloud
-192.12.185.131   os-sto-1.cnv.massopen.cloud
-192.12.185.132   os-sto-2.cnv.massopen.cloud
-192.12.185.140   provisioner.cnv2.massopen.cloud
-192.12.185.141   api.cnv2.massopen.cloud
-192.12.185.142   ns1.cnv2.massopen.cloud
-192.12.185.143   lb.cnv2.massopen.cloud
-192.12.185.144   bootstrap.cnv2.massopen.cloud
-192.12.185.145   openshift-master-0.cnv2.massopen.cloud
-192.12.185.146   openshift-master-1.cnv2.massopen.cloud
-192.12.185.147   openshift-master-2.cnv2.massopen.cloud
-192.12.185.148   openshift-worker-0.cnv2.massopen.cloud
-192.12.185.149   openshift-worker-1.cnv2.massopen.cloud
 
-192.12.185.150   provisioner.ocp.massopen.cloud (neu-5-3)
-192.12.185.151   api.ocp.massopen.cloud
-192.12.185.152   ns1.ocp.massopen.cloud
-192.12.185.153   lb.ocp.massopen.cloud
-192.12.185.154   bootstrap.ocp.massopen.cloud
-192.12.185.155   openshift-master-0.ocp.massopen.cloud (neu-3-11)
-192.12.185.156   openshift-master-1.ocp.massopen.cloud (neu-5-10)
-192.12.185.157   openshift-master-2.ocp.massopen.cloud (neu-15-9)
-192.12.185.158   openshift-worker-0.ocp.massopen.cloud (neu-5-4)
-192.12.185.159   openshift-worker-1.ocp.massopen.cloud (neu-15-4)
-192.12.185.160   openshift-worker-2-gpu.ocp.massopen.cloud (neu-17-12)
-
-192.12.185.170   provisioner.curator.massopen.cloud (neu-15-29)
-192.12.185.171   api.curator.massopen.cloud
-192.12.185.172   ns1.curator.massopen.cloud
-192.12.185.173   lb.curator.massopen.cloud
-192.12.185.174   bootstrap.curator.massopen.cloud
-192.12.185.175   os-ctrl-0.curator.massopen.cloud (neu-15-5)
-192.12.185.176   os-ctrl-1.curator.massopen.cloud (neu-3-5)
-192.12.185.177   os-ctrl-2.curator.massopen.cloud (neu-5-7)
-
-192.12.185.179   my router (so OCP workers can reach nvcr.io)
-192.12.185.180   production OCP metallb range start
-192.12.185.250   production OCP metallb range stop
-192.12.185.251   bu-21-9.massopen.cloud
 
 192.12.185.254   ov3.massopen.cloud (though this name resolves to 129.10.5.103)
 ```
@@ -163,22 +84,12 @@ IP Address       Hostname/Description
 
 128.52.60.2      Start: CSAIL Reserved
 128.52.60.20     End: CSAIL Reserved
-
 128.52.60.21     Start: MOC Infrastructure reserved
 128.52.60.30     End: MOC Infrastructure reserved
 
-128.52.60.31     Smaug openshift cluster: API Virtual IP
-128.52.60.32     Smaug openshift cluster: Ingress Virtual IP
 128.52.60.33     ocp-prod cluster: API Virtual IP
 128.52.60.34     ocp-prod cluster: Ingress Virtual IP
-128.52.60.35     ocp-staging cluster: API Virtual IP
-128.52.60.36     ocp-staging cluster: Ingress Virtual IP
 
-128.52.60.50     Start: ocp-staging openshift cluster tentant IP
-128.52.60.60     End: ocp-staging openshift cluster tentant IP
-
-128.52.61.0      Start: Smaug openshift cluster Tenant IP (128.52.61.0/25)
-128.52.61.127    End: Smaug openshift cluster Tenant IP (128.52.61.0/25)
 128.52.61.128    Start: OCP-PROD openshift cluster Tenant IP (128.52.61.128/25)
 128.52.61.255    End: OCP-PROD openshift cluster Tenant IP (128.52.61.128/25)
 
@@ -205,9 +116,6 @@ IP Address       Hostname/Description
 10.0.0.6         kzn-ipmi2-gw.infra.massopen.cloud ***ON 1GB VLAN 2 TAGGED ***
 10.0.0.7         switchback.massopen.cloud (The host that backs up switch configurations).
 10.0.0.8         promtest.massopen.cloud (Test promotheus instance. Talk to Lars/Naved about it).
-10.0.0.9         p9con.massopen.cloud
-10.0.0.50        dhcp1-ipmi.cnv.massopen.cloud
-10.0.0.51        dhcp2-ipmi.cnv.massopen.cloud
 10.0.0.255       kzn-h.infra.massopen.cloud
 10.0.3.140       ov3.massopen.cloud/kzn-e.massopen.cloud over BU public IPs from Kumo
 10.0.5.140       ov2.massopen.cloud
@@ -438,17 +346,6 @@ IP Address       Hostname/Description
 ```
  -  Defauly gateway at 172.16.96.1 connects to internet. Will be registered in HIL so nodes can access internet.
 
-## Staging Foreman: 172.17.0.0/19 (VLAN 269)
-
-```
-IP Address       Hostname/Description
-172.17.0.1       kzn-router.infra.massopen.cloud
-172.17.0.3       Foreman
-172.17.0.5       Undercloud VM for staging
-172.17.0.5       kzn-ipmi-gw.infra.massopen.cloud
-
-```
-
 
 ## BMI Provisioning (VLAN 500)
 
@@ -478,9 +375,6 @@ IP Address       Hostname/Description
 ```
 
 ## CSAIL-3801 Public IPs; 128.31.20.0/22 (VLAN 3801)
-
-We get this VLAN the same way we get CSAIL-10, i.e., from engage1 switches
-and those are directly connected to CSAIL switches.
 
 Statically assigned IPs on this network are:
 
@@ -522,38 +416,10 @@ IP Address       Hostname/Description
 192.168.32.1     kzn-rmon1 kzn-rmon1.infra.massopen.cloud
 192.168.32.2     kzn-rmon2 kzn-rmon2.infra.massopen.cloud
 192.168.32.3     kzn-rmon3 kzn-rmon3.infra.massopen.cloud
-192.168.32.4     kzn-ssh.infra.massopen.cloud
 192.168.32.5     kzn-rtr.infra.massopen.cloud
 192.168.32.6     kzn-zabbix
 
-192.168.35.21    neu-3-21 neu-3-21.infra.massopen.cloud
-192.168.35.22    neu-3-22 neu-3-22.infra.massopen.cloud
-192.168.35.23    neu-3-23 neu-3-23.infra.massopen.cloud
-192.168.35.41    neu-3-41 neu-3-41.infra.massopen.cloud (cache-server)
-
-192.168.37.21    neu-5-21 neu-5-21.infra.massopen.cloud
-192.168.37.22    neu-5-22 neu-5-22.infra.massopen.cloud
-192.168.37.23    neu-5-23 neu-5-23.infra.massopen.cloud
-192.168.37.41    neu-5-41 neu-5-41.infra.massopen.cloud (cache-server)
-
-192.168.47.21    neu-15-21 neu-15-21.infra.massopen.cloud
-192.168.47.22    neu-15-22 neu-15-22.infra.massopen.cloud
-192.168.47.23    neu-15-23 neu-15-23.infra.massopen.cloud
-192.168.47.41    neu-15-41 neu-15-41.infra.massopen.cloud (cache-server)
 ```
--  HIL/BMI users need to have access to ceph-public network (HIL admin
-   operation), add it to their project/nodes/nics and configure an ip, ip is
-   calculated as described below (user operations)
--  For client IPs use 192.168.32+Cnum.Unum mask 255.255.224.0, where Cnum is
-   cage number and Unum is U number. Cage and U numbers are used in node mame -
-   neu-1-21 means Cage 1, U 21 and the ip would be 192.168.33.21
--  Ssh access is by using FreeIpa accounts, nodes are accessible from BMI
-   provision subnet (500) by name. Ssh to monitor nodes to get ceph.conf and
-   admin keyring.
--  Please use ecrbd pool for rbd images to save disk space. To create an image
-   using erasure coded pool for data storage use `rbd create mynewrbdimage
-   --data-pool ecrbd --size xxxG`
--  *Be careful with the number of placement groups if creating new pools*
 
 ## VPN range
 

--- a/docs/source/networking/moc-vlan-distribution.md
+++ b/docs/source/networking/moc-vlan-distribution.md
@@ -22,18 +22,14 @@ All these services are highly available VMs.
  1. FreeIPA server (one will be duplicated at BU),
  1. Foreman (might be multiple for different env)
  1. RHEL repo server, just 1 for all environemtns. Public IP with limited access.
- 1. HIL server (maybe multiple for different environments)
- 1. Gateway/router for HIL/BMI services (again, could be multiple)
- 1. HIL client (again, could be multiple)
- 1. DNS servers for massopen.cloud, openapp.cloud, mocapps.cloud
+ 1. Gateway/routers
+ 1. DNS servers for massopen.cloud
     - 1 Management instance and 2 DNS servers for massopen.cloud
     - same thing for the other 2 domains.
     - a total of 6 VMs
  1. Additional internal DNS
  1. Kaizen's RadosGW will be here.
- 1. cacti - for statistics
  1. Nagios - for monitoring.
- 1. Other ssh gateways.
  1. IPMI gateways.
 
 Each environment gets around 300 to 400 VLANs which will leave room for expansion for more environments. \
@@ -49,15 +45,10 @@ Below is the detailed distribution of the VLANs.
 | 3800      | For connecting environments, but we don't know about bandwidth, or the route | -               |
 | 3801-3803 | CSAIL Floating IPs                                                           | 128.31.XX.YY/22 |
 
-## Kaizen
+## Kaizen (R4-PA-C02 and C04)
 **Hardware Summary**
- -  25 openstack computes (Dell IBs)
  -  3 oVirt nodes (Dell IBs)
- -  48 Cisco nodes. (Will be available for Elastic HW)
- -  3+2 openstack controllers (Dell SBs)
- -  8 ceph OSDs (right now, we can change this).
- -  64 Dell SB nodes that can be elastic with 2 drives each which we can redistribute. Extra 5 drives for spares.
- Total Elastic Nodes = 48 Cisco + 64 Dell SB  = 112 nodes.
+ -  10 ceph OSD servers (right now, we can change this).
 
 **VLANs**
  -  VLAN range : 201 to 700 (total 399 VLANs)
@@ -68,93 +59,39 @@ Below is the detailed distribution of the VLANs.
 | ---- | ------------------------------------------------------- | -------------- |
 | 127  | Openstack public facing services (horizon, keystone)    | 129.10.5.0/24  |
 | 201  | Foreman Provisioning. SNMP for OpenStack and Ceph       | 172.16.0.0/19  |
-| 202  | OpenStack internal API)                                 | 172.16.32.0/19 |
-| 203  | OpenStack tenant network                                | 172.16.64.0/19 |
 | 204  | Intranet (routable to internet). SNMP for client nodes. | 172.16.96.0/19 |
 | 205  | Gluster/VM migration - oVirt                            | 192.168.0.0/24 |
-| 206  | OStack isolation native vlan for trunk only ports       | N/A            |
 | 207  | For OCT/UMass Switch Management                         | 10.1.0.0/24    |
 | 208  | ESI control plane                                       | --             |
-| 209  | Openshift Internal (Baremetal 4.x)                      | --             |
-| 210  | NFS for zero cluster                                    | 10.253.0.0/23  |
 | 211  | New England Storage Exchange (NESE)                     | 10.120.0.0/22  |
-| 212  | Openshift Staging Internal (`ocp-staging`)              | --             |
 | 213  | Ceph Cluster iSCSI                                      | 10.21.0.0/22   |
 | 249  | Ceph Cluster (internal)                                 |192.168.40.0/23 |
 | 250  | Ceph public (for clients)                               | 192.168.0.0/19 |
-| 259  | Staging - Foreman                                       | 172.17.0.0/19  |
-| 270  | Staging - Internal API                                  | To be decided  |
-| 271  | Staging - Tenant Network                                | To be decided  |
-| 272  | Staging - Public Network                                | To be decided  |
-| 273  | Staging - OS Stack isolation for trunk only ports       | To be decided  |
 | 290  | OKD internal network                                    | 10.5.0.0/24    |
 | 911  | For OCT/UMass nodes IPMI                                | 10.2.0.0/19    |
 | 912  | For OCT/UMass nodes IPMI for operate first              | 10.3.0.0/19    |
 | 913  | For OKD nodes in OCT4 IPMI                              | 10.4.0.0/19    |
 | 3802 | OpenStack Tenant Floating IPs                           | 128.31.24.0/22 |
+| 3801 | ESI Tenant Floating IPs                           | 128.31.20.0/22                 |
 
-IPs in VLAN 204 will be assigned based on rack and unit number, rest will be regular DHCP.
-Eg; a node in cage 3 unit 20 will get an ip like 172.16.96+3.20
 
-VLANs 251 to 600 will be reserved for HIL and BMI. If each tenant needs at least 5 VLANs for their project in HIL,
-then with approximately 350 VLANs we can support a decent number of tenants with room for expansion.
+VLANs 251 to 600 will be reserved for ESI.
 
-Kaizen Floating IP Split:
- -  3802 (Kzn) is 128.31.24.0/22 (i.e., 2K IP)
- -  Start 128.31.24.129 - End 128.31.27.254
 
-Kzn split
- -  Old: 128.31.24.129,128.31.25.255
- -  New: 128.31.26.0,128.31.27.254
-
-## Engage1
-**Hardware Summary**
- -  12 OpenStack computes right now. 3 nodes with GPUs will be moved to Kaizen so we'll have 9 OpenStack computes.
- -  2 OpenStack Controllers
- -  3 monitors and 10 OSDs.
- -  4 services nodes. And some more extra nodes.
-
-**VLANs**
- -  VLAN Range: 701 to 1000 (total 299 VLANs)
- -  701 to 900 - 10G networks.
- -  901 to 1000 for IPMI/management on 1G networks.
-
-| VLAN | Description                                             | Subnet                         |
-| ---- | ------------------------------------------------------- | ------------------------------ |
-| 10   | Openstack public facing services (horizon, keystone)    | DHCP from CSAIL 128.52.60.0/22 |
-| 701  | Foreman Provisioning. SNMP for OpenStack and Ceph       | 172.17.0.0/19                  |
-| 702  | OpenStack internal API)                                 | 172.17.32.0/19                 |
-| 703  | OpenStack tenant network                                | 172.17.64.0/19                 |
-| 704  | Intranet (routable to internet). SNMP for client nodes. | 172.17.96.0/19                 |
-| 749  | Ceph Cluster (internal)                                 | --                             |
-| 750  | Ceph public (for clients)                               | --                             |
-| 3801 | OpenStack Tenant Floating IPs                           | 128.31.20.0/22                 |
-
-VLAN 751 to 1000 will be reserved for HIL and BMI.
-
-## Kumo
+## Kumo (R4-PA-C23)
 **Hardware Summary**
  -  16 Dell Blades
  -  1 kumo-storage hosting all services.
  -  1 kumo-services, and 1 kumo-emergency.
 
 **VLANs**
- -  VLAN Range: 1001 to 1300 (total 299 VLANs)
- -  1001 to 1200 for 10G stuff
- -  1201 to 1300 for IPMI/Management on 1G networks.
-
 | VLAN | Description                                             | Subnet          |
 | ---- | ------------------------------------------------------- | --------------- |
 | 105  | Public IPs from BU                                      | 192.12.185.0/24 |
-| 1004 | Intranet (routable to internet). SNMP for client nodes. | 172.18.0.0/19   |
-| 3808 | Public IPs                                              | 128.31.28.0/24  |
-
- -  Rest of the VLANs will be reserved for HIL in this environment.
- -  This leaves us with VLANs 1300 to 4094 for expansion in the future
+| 3803 | Public IPs                                              | 128.31.28.0/24  |
 
 
 ## NERC
-
 
 | VLAN | Description                                             | Subnet          |
 | ---- | ------------------------------------------------------- | --------------- |

--- a/docs/source/networking/public-network-providers.md
+++ b/docs/source/networking/public-network-providers.md
@@ -11,20 +11,17 @@ There are 4 networks we use from CSAIL. For help, we should contact help@csail.m
 
 Subnet: 128.52.60.0/22
 
-We used this for infrastructure in engage1 but we have to use CSAIL's DHCP since
-they like to control this network, which makes this less desirable.
+This was used for various openshift clusters but should be free soon.
+
 As of 8/12/2021, the DHCP range on this network is 128.52.62.128/25.
 
-Our brocade switches in BU cages 2 and 4 connect to the CSAIL switch to access
-this network.
-
+This network is temporarily on the OCT-CORE switches.
 
 **VLAN 3801**
 
 Subnet: 128.31.20.0/22
 
-We used this for engage1. Our brocade switches in BU cages 2 and 4 connect to
-the CSAIL switch to access this network.
+This has been assigned to ESI pilot. We get this vlan from the OCT-CORE switches.
 
 
 **VLAN 3802**
@@ -42,14 +39,6 @@ Subnet: 128.31.28.0/24
 This is used for MaaS services and hosts, and some infrastructure VMs.
 Our Cisco switch in Kumo (Row 4 Pod A Cage) connects to a BU switch which
 carries this VLAN in addition to BU's public network (VLAN 105, 192.12.185.0/24).
-
-**Note**
-
-We have no servers racked in MIT space.
-The cluster we call enage1 at MOC is racked in BU cages 2 and 4 (Row 4 Pod A).
-We have 4 brocade switches racked in those cages and they are part of a brocade fabric
-where the rest of the brocade switches (5) are racked in MIT cages. We should figure who
-gets dibs on those switches. The brocade switches that connect to CSAIL are in our cages so that's good.
 
 
 ## BU


### PR DESCRIPTION
We have deprecated R3-PB and a bunch of services (openstack, hil/bmi, various openshift clusters). So, this was a good time to clean up our IP and VLAN allocations.

Let me know if there's some IP or VLANs that we could get rid of.