### PR TITLE
Added `readthedocs.yaml` file needed for ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
Closes CCI-MOC/ops-issues#1312. Apparently, readthedocs.org requires Github documentation repos to have a `readthedocs.yaml` file in the top-level of the repo (https://docs.readthedocs.io/en/stable/config-file/index.html)

The file itself seemed to have been implemented as an optional file many years before our builds started failing, but the commit that made it a requirement was around June 2023
(https://github.com/readthedocs/readthedocs.org/commit/ac7264700a843f746943255d534781bff02ae712)

I have added the minimal configuration settings
Documentation for the config file is here:
https://docs.readthedocs.io/en/stable/config-file/index.html#